### PR TITLE
add configuration option to allow self signed tls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,10 @@
 #
 FIREFLY_III_ACCESS_TOKEN=
 FIREFLY_III_URI=http://
-FIREFLY_III_VERIFY_TLS_CERT=true
+
+# Path to a self-signed certificate.
+# Commenting it out will trust system certificates.
+#FIREFLY_III_TRUSTED_CERT=/path/to/cert.pem
 
 #
 # Spectre information. Get this from your profile over at Spectre.

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@
 #
 FIREFLY_III_ACCESS_TOKEN=
 FIREFLY_III_URI=http://
+FIREFLY_III_VERIFY_TLS_CERT=true
 
 #
 # Spectre information. Get this from your profile over at Spectre.

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+.idea
+*.iml
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
-.idea
-*.iml
-.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ENV HOMEPATH=/var/www/html COMPOSER_ALLOW_SUPERUSER=1
 LABEL version="dev"
 
 # Fetch scripts from helper repo :/
-RUN curl -SL https://raw.githubusercontent.com/firefly-iii/spectre-importer-docker/master/scripts/site.conf -o /etc/apache2/sites-available/000-default.conf && \
-    curl -SL https://raw.githubusercontent.com/firefly-iii/spectre-importer-docker/master/scripts/entrypoint.sh -o /entrypoint.sh
+RUN curl -SL https://raw.githubusercontent.com/lfuelling/spectre-importer-docker/master/scripts/site.conf -o /etc/apache2/sites-available/000-default.conf && \
+    curl -SL https://raw.githubusercontent.com/lfuelling/spectre-importer-docker/master/scripts/entrypoint.sh -o /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM fireflyiii/tools-base-image:latest-amd64
+# To learn more about this base image, visit https://github.com/firefly-iii/tools-base-image
+
+ENV VERSION=dev
+
+ENV HOMEPATH=/var/www/html COMPOSER_ALLOW_SUPERUSER=1
+LABEL version="dev"
+
+# Fetch scripts from helper repo :/
+RUN curl -SL https://raw.githubusercontent.com/firefly-iii/spectre-importer-docker/master/scripts/site.conf -o /etc/apache2/sites-available/000-default.conf && \
+    curl -SL https://raw.githubusercontent.com/firefly-iii/spectre-importer-docker/master/scripts/entrypoint.sh -o /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+COPY ./ $HOMEPATH
+
+WORKDIR $HOMEPATH
+RUN chown -R www-data:www-data $HOMEPATH && \
+    chmod -R 775 $HOMEPATH/storage && \
+    composer install --prefer-dist --no-dev --no-scripts --no-suggest
+
+# Expose port 80
+EXPOSE 80
+
+# Run entrypoint thing
+ENTRYPOINT ["/entrypoint.sh"]

--- a/app/Console/HaveAccess.php
+++ b/app/Console/HaveAccess.php
@@ -39,7 +39,7 @@ trait HaveAccess
     {
         $uri     = (string) config('spectre.uri');
         $token   = (string) config('spectre.access_token');
-        $request = new SystemInformationRequest($uri, $token);
+        $request = new SystemInformationRequest($uri, $token, (string) config('spectre.trusted_cert'));
         try {
             $request->get();
         } catch (ApiHttpException $e) {

--- a/app/Http/Controllers/Import/ConfigurationController.php
+++ b/app/Http/Controllers/Import/ConfigurationController.php
@@ -70,7 +70,7 @@ class ConfigurationController extends Controller
         // get list of asset accounts in Firefly III
         $uri         = (string) config('spectre.uri');
         $token       = (string) config('spectre.access_token');
-        $accountList = new GetAccountsRequest($uri, $token);
+        $accountList = new GetAccountsRequest($uri, $token, (string) config('spectre.trusted_cert'));
         $accountList->setType(GetAccountsRequest::ASSET);
         $ff3Accounts = $accountList->get();
 

--- a/app/Http/Controllers/Import/MappingController.php
+++ b/app/Http/Controllers/Import/MappingController.php
@@ -140,7 +140,7 @@ class MappingController extends Controller
     {
         $token   = (string) config('spectre.access_token');
         $uri     = (string) config('spectre.uri');
-        $request = new GetAccountsRequest($uri, $token);
+        $request = new GetAccountsRequest($uri, $token, (string) config('spectre.trusted_cert'));
         /** @var GetAccountsResponse $result */
         $result = $request->get();
         $return = [];
@@ -170,7 +170,7 @@ class MappingController extends Controller
     {
         $token   = (string) config('spectre.access_token');
         $uri     = (string) config('spectre.uri');
-        $request = new GetCategoriesRequest($uri, $token);
+        $request = new GetCategoriesRequest($uri, $token, (string) config('spectre.trusted_cert'));
         /** @var GetCategoriesResponse $result */
         $result = $request->get();
         $return = [];

--- a/app/Http/Controllers/TokenController.php
+++ b/app/Http/Controllers/TokenController.php
@@ -116,7 +116,7 @@ class TokenController extends Controller
         // verify access
         $uri     = (string) config('spectre.uri');
         $token   = (string) config('spectre.access_token');
-        $request = new SystemInformationRequest($uri, $token);
+        $request = new SystemInformationRequest($uri, $token, (string) config('spectre.trusted_cert'));
         try {
             $result = $request->get();
         } catch (ApiHttpException $e) {

--- a/app/Services/Spectre/Request/Request.php
+++ b/app/Services/Spectre/Request/Request.php
@@ -346,7 +346,7 @@ abstract class Request
         // config here
 
         return new Client(array (
-            'verify' => (string) config('spectre.verify_cert')
+            'verify' => (string) config('spectre.verify_cert') === 'true'
         ));
     }
 

--- a/app/Services/Spectre/Request/Request.php
+++ b/app/Services/Spectre/Request/Request.php
@@ -242,7 +242,7 @@ abstract class Request
 
         Log::debug('Final headers for spectre signed POST request:', $headers);
         try {
-            $client = new Client;
+            $client = $this->getClient();
             $res    = $client->request('POST', $fullUri, ['headers' => $headers, 'body' => $body]);
         } catch (GuzzleException|Exception $e) {
             throw new ImportException(sprintf('Guzzle Exception: %s', $e->getMessage()));
@@ -297,7 +297,7 @@ abstract class Request
 
         Log::debug('Final headers for spectre UNsigned POST request:', $headers);
         try {
-            $client = new Client;
+            $client = $this->getClient();
             $res    = $client->request('POST', $fullUri, $opts);
         } catch (GuzzleException|Exception $e) {
             Log::error($e->getMessage());
@@ -345,7 +345,9 @@ abstract class Request
     {
         // config here
 
-        return new Client;
+        return new Client(array (
+            'verify' => (string) config('spectre.verify_cert')
+        ));
     }
 
     /**

--- a/app/Services/Spectre/Request/Request.php
+++ b/app/Services/Spectre/Request/Request.php
@@ -345,9 +345,7 @@ abstract class Request
     {
         // config here
 
-        return new Client(array (
-            'verify' => (string) config('spectre.verify_cert') === 'true'
-        ));
+        return new Client;
     }
 
     /**

--- a/app/Services/Spectre/Request/Request.php
+++ b/app/Services/Spectre/Request/Request.php
@@ -193,7 +193,7 @@ abstract class Request
         }
         if (null !== $res && 200 !== $res->getStatusCode()) {
             // return body, class must handle this
-            Log::error(sprintf('Status code is %d: %s', $res->getStatusCode(), $e->getMessage()));
+            Log::error(sprintf('Status code is %d', $res->getStatusCode()));
 
             $body = (string) $res->getBody();
         }

--- a/app/Services/Sync/GenerateTransactions.php
+++ b/app/Services/Sync/GenerateTransactions.php
@@ -71,7 +71,7 @@ class GenerateTransactions
         // send account list request to Firefly III.
         $token   = (string) config('spectre.access_token');
         $uri     = (string) config('spectre.uri');
-        $request = new GetAccountsRequest($uri, $token);
+        $request = new GetAccountsRequest($uri, $token, (string) config('spectre.trusted_cert'));
         /** @var GetAccountsResponse $result */
         $result = $request->get();
         $return = [];
@@ -215,7 +215,7 @@ class GenerateTransactions
         $uri   = (string) config('spectre.uri');
         $token = (string) config('spectre.access_token');
         app('log')->debug(sprintf('Going to download account #%d', $accountId));
-        $request = new GetAccountRequest($uri, $token);
+        $request = new GetAccountRequest($uri, $token, (string) config('spectre.trusted_cert'));
         $request->setId($accountId);
         /** @var GetAccountResponse $result */
         $result = $request->get();

--- a/app/Services/Sync/SendTransactions.php
+++ b/app/Services/Sync/SendTransactions.php
@@ -78,7 +78,7 @@ class SendTransactions
      */
     private function sendTransaction(string $uri, string $token, int $index, array $transaction): array
     {
-        $request = new PostTransactionRequest($uri, $token);
+        $request = new PostTransactionRequest($uri, $token, (string) config('spectre.trusted_cert'));
         $request->setBody($transaction);
         try {
             /** @var PostTransactionResponse $response */

--- a/config/spectre.php
+++ b/config/spectre.php
@@ -27,6 +27,7 @@ return [
     'version'         => '1.0.0-alpha.4',
     'access_token'    => env('FIREFLY_III_ACCESS_TOKEN'),
     'uri'             => env('FIREFLY_III_URI'),
+    'verify_cert'     => env('FIREFLY_III_VERIFY_TLS_CERT'),
     'upload_path'     => storage_path('uploads'),
     'minimum_version' => '5.2.8',
     'spectre_app_id'  => env('SPECTRE_APP_ID', ''),

--- a/config/spectre.php
+++ b/config/spectre.php
@@ -27,7 +27,7 @@ return [
     'version'         => '1.0.0-alpha.4',
     'access_token'    => env('FIREFLY_III_ACCESS_TOKEN'),
     'uri'             => env('FIREFLY_III_URI'),
-    'verify_cert'     => env('FIREFLY_III_VERIFY_TLS_CERT'),
+    'trusted_cert'     => env('FIREFLY_III_TRUSTED_CERT', null),
     'upload_path'     => storage_path('uploads'),
     'minimum_version' => '5.2.8',
     'spectre_app_id'  => env('SPECTRE_APP_ID', ''),


### PR DESCRIPTION
Hi @JC5,
this PR fixes issue firefly-iii/firefly-iii#3470 by adding a configuration option to skip the certificate verification of Guzzle.

~~I've never written PHP > 5  (or used Laravel) before so I'm unsure wether this is all correct but I can't find a Dockerfile for testing it (see firefly-iii/firefly-iii#3471).~~

I was able to test it, unfortunately something still does not work.